### PR TITLE
Create new file for Metadata Version

### DIFF
--- a/make_run.py
+++ b/make_run.py
@@ -31,13 +31,16 @@ def main():
     for subdir in subdirs:
         subdir_path = os.path.join(run_dir, subdir)
         os.mkdir(subdir_path)
-        cprint(f"  Sub-directory {subdir_path} created", "green")
+        print(f"  Sub-directory ", end="")
+        cprint(subdir_path, "yellow", end=" ")
+        print("created")
 
     # Copy the default config.ini
     config_path = os.path.join(run_dir, 'config.ini')
     
     shutil.copy('suncet_processing_pipeline/config_files/config_default.ini', config_path)
-    cprint(f"Copied {config_path}", "green")
+    print(f"Copied ", end="")
+    cprint(config_path, "yellow")
 
     # Print final message stating success
     print("Run creation completed successfully")


### PR DESCRIPTION
This merge request updates the `setup_minimum_required_folders_files.py` to also write a file called `suncet_metadata_definition_version.csv` adjacent to the `suncet_metadata_definition.csv`. 

If you download the metadata from a dropbox URL, it infers the version from the filename in the URL. If you download it directly from the live version on Google Drive, the version will be "live". If it can't figure out the version otherwise, it uses "unknown" and prints a red error message.

The new file will be used to obtain the metadata version for insertion into the FITS/NetCDF/Zar headers, which will be useful for later debugging.

I also tweaked the colors in make_run.py