### PR TITLE
Add load_from_fits() function FITS to Metadata Manager class

### DIFF
--- a/suncet_processing_pipeline/make_level3.py
+++ b/suncet_processing_pipeline/make_level3.py
@@ -45,18 +45,50 @@ class Level3:
         
         # Write fits file
         fits_path = self.run_dir / 'level3' / 'output.fits'
-        fits_file = fits.open(fits_path, "append")
 
+        if fits_path.exists():
+            fits_path.unlink()
+
+        fits_file = fits.open(fits_path, "append")
+        
         image_data = np.zeros((1024, 1024), dtype=np.uint16)
         hdu = fits.ImageHDU(image_data)
         fits_file.append(hdu)
 
         metadata.generate_fits_header(fits_file)
 
-        print(f'Wrote to {fits_path}')
+        cprint(f'Wrote to {fits_path}', 'green')
         print()
         print(repr(fits_file[0].header))
-    
+
+        fits_file.close()
+
+        print()
+        
+        # Test loading metadata from FITS
+        cprint('Starting new FITS file', 'green')
+
+        metadata_new = metadata_managers.FitsMetadataManager(self.run_dir)
+        metadata_new.load_from_fits(fits_path)
+
+        print('Loaded metadata from previous FITS:')
+        print(metadata_new._metadata_values)
+
+        fits_path_new = self.run_dir / 'level3' / 'output_new.fits'
+
+        if fits_path_new.exists():
+            fits_path_new.unlink()
+
+        fits_file_new = fits.open(fits_path_new, "append")
+        hdu = fits.ImageHDU(image_data)
+        fits_file_new.append(hdu)
+            
+        metadata.generate_fits_header(fits_file_new)
+        print()
+        print(repr(fits_file_new[0].header))
+
+        fits_file_new.close()
+        
 
 def final_shdr_compositing_fix(level2_data, config):
     """Fix any lingaring SHDR Compositing Issues.


### PR DESCRIPTION
This adds a method `load_from_fits(fits_file)` to the metadata manager class. With this method, you provide a FITS file and it adds the metadata from that FITS file to the current metadata manager instance (similar to `load_from_dict()`. 

This feature is useful to carry metadata forward between different stages of processing, e.g. Level 2 -> Level 3.

An example of using this method was placed in the `make_level3.py` script. An example invocation is below.

![image](https://github.com/user-attachments/assets/2eb498f3-57fa-4abc-a585-f65995412d23)
